### PR TITLE
feat: Add subissue command for creating sub-issues

### DIFF
--- a/src/services/linear-service.ts
+++ b/src/services/linear-service.ts
@@ -448,6 +448,7 @@ export class LinearService {
           priority,
           estimate,
           labelIds: resolvedLabelIds,
+          parentId: params.parentId,
         });
 
         const issue = await issuePayload.issue;
@@ -492,6 +493,7 @@ export class LinearService {
           priority,
           estimate,
           labelIds: resolvedLabelIds,
+          parentId: params.parentId,
         });
 
         const issue = await issuePayload.issue;


### PR DESCRIPTION
## Summary
- Fixed bug where parentId parameter was not passed to Linear SDK
- Added new `mcp__linear__create_subissue` command
- Sub-issues automatically inherit parent's teamId

## Test Plan
- [ ] Build passes with `npm run build`
- [ ] TypeScript checks pass with `npm run typecheck`
- [ ] Test creating a sub-issue with the new command
- [ ] Verify sub-issue is created under the correct parent

Implements MCP-15

🤖 Generated with [Claude Code](https://claude.ai/code)