### PR TITLE
fix: Auto-resolve parentId from identifier to UUID in create_subissue

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -419,12 +419,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         const teamId = teamMatch[1];
         
-        // Create the sub-issue with the parent's teamId and the provided parentId
+        // Extract the parent issue UUID from the markdown
+        const idMatch = parentIssueData.markdown.match(/\*\*ID:\*\* `([a-f0-9-]+)`/);
+        if (!idMatch || !idMatch[1]) {
+          throw new Error(`Could not extract UUID for parent issue ${String(args?.parentId)}`);
+        }
+        const parentUuid = idMatch[1];
+        
+        // Create the sub-issue with the parent's teamId and resolved UUID
         const subissueArgs = {
           title: args?.title,
           description: args?.description,
           teamId: teamId,
-          parentId: args?.parentId,
+          parentId: parentUuid,
           stateId: args?.stateId,
           labelIds: args?.labelIds
         };


### PR DESCRIPTION
## Summary
- Fixed the `create_subissue` function to properly resolve parent issue identifiers (e.g., "MCP-15") to UUIDs before passing to the Linear API
- Extracts the UUID from the parent issue's markdown response
- Prevents "parentId must be a UUID" error when creating sub-issues

## Test Plan
- [x] Build passes
- [ ] Manual testing: Create a sub-issue using an identifier like "MCP-15" as parentId
- [ ] Verify sub-issue is created successfully with correct parent relationship

Fixes MCP-16

🤖 Generated with [Claude Code](https://claude.ai/code)