### PR TITLE
docs: add Node.js version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 An MCP server that connects Claude Code to Linear with OAuth authentication and multi-workspace support.
 
+## Requirements
+
+- Node.js 18+
+- A [Linear](https://linear.app) account
+
 ## Quick Start
 
 ### 1. Install


### PR DESCRIPTION
Adds a "Requirements" section to the README listing Node.js 18+ and a Linear account as prerequisites.

This is a sample PR created to verify cross-project Cairn issue creation from the AGGDCS manager agent.